### PR TITLE
Add new Operator's to HostTag field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nixys/nxs-go-zabbix/v5
+module github.com/Mosslar/nxs-go-zabbix/v5
 
 go 1.14
 

--- a/host.go
+++ b/host.go
@@ -103,6 +103,10 @@ const (
 const (
 	HostTagOperatorContains = 0
 	HostTagOperatorEquals   = 1
+	HostTagNotLike = 2
+	HostTagNotEqual =3
+	HostTagExists = 4
+	HostTagNotExists = 5
 )
 
 // HostObject struct is used to store host operations results


### PR DESCRIPTION
https://www.zabbix.com/documentation/current/en/manual/api/reference/host/get

New Operator's is  coming for Zabbix =>5.4

Possible operator values:
0 - (default) Contains;
1 - Equals;
2 - Not like;
3 - Not equal
4 - Exists;
5 - Not exists.
